### PR TITLE
ぼっちぬめろんのwordLogを正常に動作するように

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+### .log/ ###
 
 ### STS ###
 .apt_generated

--- a/src/main/java/oit/is/work/team2/model/User.java
+++ b/src/main/java/oit/is/work/team2/model/User.java
@@ -5,6 +5,9 @@ public class User {
     private String name;
     private int roomId;
 
+    public User() {
+    }
+
     public void setId(int id) {
         this.id = id;
     }

--- a/src/main/java/oit/is/work/team2/model/UserMapper.java
+++ b/src/main/java/oit/is/work/team2/model/UserMapper.java
@@ -1,25 +1,41 @@
 package oit.is.work.team2.model;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface UserMapper {
-    @Select("SELECT id, name from users where id = #{id}")
+    @Select("SELECT id, name FROM users WHERE id = #{id}")
     User selectById(String id);
 
-    @Select("SELECT id, name from users where name = #{name}")
+    @Select("SELECT id, name FROM users WHERE name = #{name}")
     User selectByName(String name);
 
-    @Select("SELECT id, name from users where roomId = #{roomId}")
+    @Select("SELECT id, name FROM users WHERE roomId = #{roomId}")
     User selectByRoomId(int roomId);
 
-    // roomIdのuserの数を取得
     @Select("SELECT COUNT(*) FROM users WHERE roomId = #{roomId}")
     int selectCountByRoomId(int roomId);
+
+    @Insert("INSERT INTO users (name) VALUES (#{name})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    void insertUser(User user);
+
+    @Insert("INSERT INTO users (roomId, name) VALUES (#{roomId}, #{name})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    void insertWithRoomId(@Param("roomId") int roomId, @Param("name") String name);
+
+    // @Select("SELECT * FROM users")
+    // List<User> selectAll();
+
+    @Select("SELECT id FROM users WHERE name = #{name}")
+    int selectIdByName(String name);
 
     @Insert("INSERT INTO users (roomId, name) VALUES (#{roomId}, #{name})")
     void insert(int roomId, String name);

--- a/src/main/java/oit/is/work/team2/model/WordLog.java
+++ b/src/main/java/oit/is/work/team2/model/WordLog.java
@@ -2,6 +2,8 @@ package oit.is.work.team2.model;
 
 public class WordLog {
   int id;
+  int roomId;
+  int userId;
   String ans;
   int eatcnt;
   int bitecnt;
@@ -12,6 +14,22 @@ public class WordLog {
 
   public void setId(int id) {
     this.id = id;
+  }
+
+  public int roomId() {
+    return roomId;
+  }
+
+  public void setRoomId(int roomId) {
+    this.roomId = roomId;
+  }
+
+  public int userId() {
+    return userId;
+  }
+
+  public void setUserId(int userId) {
+    this.userId = userId;
   }
 
   public String getAns() {

--- a/src/main/java/oit/is/work/team2/model/WordLogMapper.java
+++ b/src/main/java/oit/is/work/team2/model/WordLogMapper.java
@@ -5,15 +5,25 @@ import java.util.ArrayList;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Delete;
 
 @Mapper
 public interface WordLogMapper {
   @Select("select * from wordLog")
   ArrayList<WordLog> selectAll();
 
+  @Select("select * from wordLog where userId = #{userId}")
+  ArrayList<WordLog> selectAllByUserId(int userId);
+
   @Select("select count(*) from wordLog")
   int dataCount();
 
   @Insert("insert into wordLog (ans, eatcnt, bitecnt) values (#{ans}, #{eatcnt}, #{bitecnt})")
   boolean insert(String ans, int eatcnt, int bitecnt);
+
+  @Insert("insert into wordLog (ans, userId, eatcnt, bitecnt) values (#{ans}, #{userId}, #{eatcnt}, #{bitecnt})")
+  boolean insertWithUserId(String ans, int userId, int eatcnt, int bitecnt);
+
+  @Delete("delete from wordLog where userId = #{userId}")
+  boolean deleteByUserId(int userId);
 }

--- a/src/main/java/oit/is/work/team2/service/AsyncPlayMatch.java
+++ b/src/main/java/oit/is/work/team2/service/AsyncPlayMatch.java
@@ -16,7 +16,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import oit.is.work.team2.model.Dictionary;
 import oit.is.work.team2.model.DictionaryMapper;
-import oit.is.work.team2.model.Match;
 import oit.is.work.team2.model.MatchMapper;
 
 import oit.is.work.team2.model.WordLog;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -16,6 +16,8 @@ CREATE TABLE dictionary (
 
 CREATE TABLE wordLog (
     id INT AUTO_INCREMENT PRIMARY KEY,
+    roomId INT,
+    userId INT,
     ans VARCHAR(255) NOT NULL,
     eatcnt INT,
     bitecnt INT

--- a/src/main/resources/templates/numeron.html
+++ b/src/main/resources/templates/numeron.html
@@ -78,8 +78,10 @@
 <body>
   <tbody sec:authorize="hasRole('ADMIN')">
     <h2><a href="/admin">adminでログイン</a></h2>
+    <br>
   </tbody>
   <h1>セレクト画面</h1>
+  <h2>はろー <span sec:authentication="name"></span></h2>
   <h2>ぼっちぬめろん</h2>
   <a href="/soloNumeron" class="btn btn-primary">START</a>
   <h2></h2>
@@ -100,7 +102,7 @@
     <p>文字の場所も一致していればeat</p>
     <p>より少ない手番で単語を当てよう！</p>
   </div>
-  <a href="../index.html">もどる</a><br>
+  <a href="/logout">ログアウト</a>
 
   <!-- Bootstrap JS and dependencies -->
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>

--- a/src/main/resources/templates/soloNumeron.html
+++ b/src/main/resources/templates/soloNumeron.html
@@ -29,7 +29,7 @@
 
 <body>
 
-  <a th:href="@{/numeron/back}">もどる</a>
+  <a th:href="@{/soloNumeron/back}">もどる</a>
 
   <h1>ぬめろん</h1>
   <p>４文字の英単語を当てるゲーム</p>


### PR DESCRIPTION
<h1>[ソロプレイ]playerごとにDBの消去を行えるようにする。</h1>
<li>this.nameでplayer情報をDBに入れようとしていたが、不具合があり、認証なしでは無理だと判断したのでplayerにも認証を追加。</li>
<li>ぼっちぬめろんを修正したら、マルチヌメロンにも影響が出たため、そっちも修正。</li>
<li>もどるボタンを押した際にDBからwordLogが削除。</li>
<h2>[DoD]</h2>
<li>ぼっちぬめろんにアクセスし、1度プレイを行い、もどるボタンを押し、もう一度プレイした際、前回の文字履歴が出力されず、現在のプレイ履歴のみになっているか</li>
<li>h2-consoleを確認する</li>
<li>マルチヌメロンに影響が出ていないか確認する</li>
