### PR TITLE
Delete db multi

### DIFF
--- a/src/main/java/oit/is/work/team2/controller/MultiNumeronController.java
+++ b/src/main/java/oit/is/work/team2/controller/MultiNumeronController.java
@@ -210,6 +210,7 @@ public class MultiNumeronController {
     int roomId = usermapper.selectRoomIdByName(prin.getName());
     wordLogMapper.deleteByRoomId(roomId);
     usermapper.deleteByRoomId(roomId);
+    matchinfomapper.resetMatchInfo(roomId);
     return "redirect:/numeron";
   }
 }

--- a/src/main/java/oit/is/work/team2/controller/MultiNumeronController.java
+++ b/src/main/java/oit/is/work/team2/controller/MultiNumeronController.java
@@ -203,4 +203,13 @@ public class MultiNumeronController {
     model.addAttribute("wordLogs", wordLogs);
     return "multiNumeron.html";
   }
+
+  // numeron.htmlに戻る
+  @GetMapping("back")
+  public String back(Principal prin) {
+    int roomId = usermapper.selectRoomIdByName(prin.getName());
+    wordLogMapper.deleteByRoomId(roomId);
+    usermapper.deleteByRoomId(roomId);
+    return "redirect:/numeron";
+  }
 }

--- a/src/main/java/oit/is/work/team2/controller/SoloNumeronController.java
+++ b/src/main/java/oit/is/work/team2/controller/SoloNumeronController.java
@@ -78,7 +78,7 @@ public class SoloNumeronController {
     if (eatcnt == 4) {
       int gamecnt = wordLogMapper.dataCount();
       model.addAttribute("gamecnt", gamecnt);
-      return "result.html";
+      return "soloResult.html";
     }
     return "soloNumeron.html";
   }

--- a/src/main/java/oit/is/work/team2/controller/SoloNumeronController.java
+++ b/src/main/java/oit/is/work/team2/controller/SoloNumeronController.java
@@ -52,7 +52,7 @@ public class SoloNumeronController {
     return "soloNumeron.html";
   }
 
-  @PostMapping("step1")
+  @PostMapping("solo")
   @Transactional
   public String solo(@RequestParam String ans, ModelMap model, Principal prin) {
     String name = prin.getName();

--- a/src/main/java/oit/is/work/team2/model/MatchInfoMapper.java
+++ b/src/main/java/oit/is/work/team2/model/MatchInfoMapper.java
@@ -37,4 +37,8 @@ public interface MatchInfoMapper {
     @Options(useGeneratedKeys = true, keyProperty = "id")
     boolean insertMatchInfo(MatchInfo matchinfo);
 
+    // idを指定してpplNumを0に,isActiveをfalseする
+    @Update("UPDATE MATCHINFO SET PPLNUM = 0, ISACTIVE = FALSE WHERE ID = #{id}")
+    boolean resetMatchInfo(int id);
+
 }

--- a/src/main/java/oit/is/work/team2/model/UserMapper.java
+++ b/src/main/java/oit/is/work/team2/model/UserMapper.java
@@ -26,6 +26,9 @@ public interface UserMapper {
     @Select("SELECT id FROM users WHERE name = #{name}")
     int selectIdByName(String name);
 
+    @Select("SELECT roomId FROM users WHERE name = #{name}")
+    int selectRoomIdByName(String name);
+
     @Select("SELECT * from users")
     ArrayList<User> selectAll();
 

--- a/src/main/java/oit/is/work/team2/model/UserMapper.java
+++ b/src/main/java/oit/is/work/team2/model/UserMapper.java
@@ -46,4 +46,8 @@ public interface UserMapper {
     // idを指定して削除
     @Delete("DELETE FROM users WHERE id = #{id}")
     void deleteById(int id);
+
+    // roomIdを指定して削除
+    @Delete("DELETE FROM users WHERE roomId = #{roomId}")
+    void deleteByRoomId(int roomId);
 }

--- a/src/main/java/oit/is/work/team2/model/WordLogMapper.java
+++ b/src/main/java/oit/is/work/team2/model/WordLogMapper.java
@@ -24,6 +24,9 @@ public interface WordLogMapper {
   @Insert("insert into wordLog (ans, eatcnt, bitecnt) values (#{ans}, #{eatcnt}, #{bitecnt})")
   boolean insert(String ans, int eatcnt, int bitecnt);
 
+  @Insert("insert into wordLog (roomId, ans, eatcnt, bitecnt) values (#{roomId}, #{ans}, #{eatcnt}, #{bitecnt})")
+  boolean insertMulti(int roomId, String ans, int eatcnt, int bitecnt);
+
   @Insert("insert into wordLog (ans, userId, eatcnt, bitecnt) values (#{ans}, #{userId}, #{eatcnt}, #{bitecnt})")
   boolean insertWithUserId(String ans, int userId, int eatcnt, int bitecnt);
 

--- a/src/main/java/oit/is/work/team2/model/WordLogMapper.java
+++ b/src/main/java/oit/is/work/team2/model/WordLogMapper.java
@@ -30,6 +30,11 @@ public interface WordLogMapper {
   @Insert("insert into wordLog (ans, userId, eatcnt, bitecnt) values (#{ans}, #{userId}, #{eatcnt}, #{bitecnt})")
   boolean insertWithUserId(String ans, int userId, int eatcnt, int bitecnt);
 
+  // userIdを指定して削除
   @Delete("delete from wordLog where userId = #{userId}")
   boolean deleteByUserId(int userId);
+
+  // roomIdを指定して削除
+  @Delete("delete from wordLog where roomId = #{roomId}")
+  boolean deleteByRoomId(int roomId);
 }

--- a/src/main/java/oit/is/work/team2/secutity/AuthConfiguration.java
+++ b/src/main/java/oit/is/work/team2/secutity/AuthConfiguration.java
@@ -28,7 +28,7 @@ public class AuthConfiguration {
             .logoutUrl("/logout")
             .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
         .authorizeHttpRequests(authz -> authz
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/admin/**")) // "/numeron/**"
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/numeron/**")) // "/admin/**"
             .authenticated() // /admin以下は認証済みであること
             .requestMatchers(AntPathRequestMatcher.antMatcher("/**"))
             .permitAll())// 上記以外は全員アクセス可能

--- a/src/main/java/oit/is/work/team2/service/AsyncPlayMatch.java
+++ b/src/main/java/oit/is/work/team2/service/AsyncPlayMatch.java
@@ -20,7 +20,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import oit.is.work.team2.model.Dictionary;
 import oit.is.work.team2.model.DictionaryMapper;
 import oit.is.work.team2.model.MatchMapper;
-
 import oit.is.work.team2.model.WordLog;
 import oit.is.work.team2.model.WordLogMapper;
 
@@ -53,9 +52,9 @@ public class AsyncPlayMatch {
   }
 
   @Transactional
-  public void syncAddWordLogs(String ans, int eatcnt, int bitecnt) {
+  public void syncAddWordLogs(int roomId, String ans, int eatcnt, int bitecnt) {
     // 追加
-    wordLogMapper.insert(ans, eatcnt, bitecnt);
+    wordLogMapper.insertMulti(roomId, ans, eatcnt, bitecnt);
     // 非同期でDB更新したことを共有する際に利用する
     this.dbUpdated = true;
     this.wdbUpdated = true;

--- a/src/main/resources/templates/multiRoom.html
+++ b/src/main/resources/templates/multiRoom.html
@@ -88,7 +88,7 @@
   <header>
     <a th:href="@{/numeron/back}">🔙もどる</a>
     <h1>ルーム選択</h1>
-    <b><span id="welcome-message">ようこそ、[[${name}]] さん</span></b><br>
+    <b><span id="welcome-message">ようこそ、<span sec:authentication="name"></span> さん</span></b><br>
   </header>
 
   <br />

--- a/src/main/resources/templates/numeron.html
+++ b/src/main/resources/templates/numeron.html
@@ -89,24 +89,19 @@
       <h2><a href="/admin">adminでログイン</a></h2>
       <br>
     </tbody>
-    <h1>セレクト画面</h1>
   </header>
-  <br />
+  <h1>GAME MODE SELECT</h1>
+  <br>
   <h2>はろー <span sec:authentication="name"></span></h2>
-  <br />
+  <br>
+  <br>
   <h2>ぼっちぬめろん</h2>
   <a href="/soloNumeron" class="btn btn-primary">START</a>
-  <br /><br />
-
-  <h2>みんなでぬめろん</h2>
-  <b>名前を入力</b>
-  <form th:action="@{multiNumeron/multiRoom}" method="post">
-    <input type="text" name="name" />
-    <div class="button-container">
-      <input type="submit" value="決定" class="btn btn-primary">
-      <input type="reset" value="取消" class="btn btn-secondary">
-    </div>
-  </form>
+  <br>
+  <br>
+  <h2>ふたりでぬめろん</h2>
+  <a href="/multiNumeron/multiRoom" class="btn btn-primary">START</a>
+  <br>
 
   <div class="description">
     <p>ぬめろんは４文字の英単語を推測して当てるゲーム！</p>

--- a/src/main/resources/templates/result.html
+++ b/src/main/resources/templates/result.html
@@ -42,7 +42,7 @@
 
         <!-- トップページへのリンク -->
         <p class="text-center">
-          <a href="/numeron" class="btn btn-primary">トップページへ戻る</a>
+          <a th:href="@{/multiNumeron/back}" class="btn btn-primary">トップページへ戻る</a>
         </p>
       </div>
     </div>

--- a/src/main/resources/templates/soloNumeron.html
+++ b/src/main/resources/templates/soloNumeron.html
@@ -79,7 +79,7 @@
   <h2>４文字の英単語を当てるゲーム</h2>
   <br /><br />
 
-  <form th:action="@{/soloNumeron/step1}" method="post">
+  <form th:action="@{/soloNumeron/solo}" method="post">
     <input type="text" name="ans" />
     <input type="submit" value="決定"><input type="reset" value="取消">
   </form>

--- a/src/main/resources/templates/soloResult.html
+++ b/src/main/resources/templates/soloResult.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>numeron result</title>
+
+  <!-- Bootstrap CSS -->
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet">
+
+  <style>
+    body {
+      background-color: #f8f9fa;
+      color: #495057;
+      font-family: 'Helvetica Neue', sans-serif;
+    }
+
+    .container {
+      margin-top: 50px;
+    }
+
+    h1 {
+      color: #007bff;
+      text-align: center;
+    }
+
+    p {
+      font-size: 20px;
+      text-align: center;
+      margin-top: 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <h1>🎉 勝利 🎉</h1>
+        <p><span th:style="'font-size: 24px; color: blue;'" th:text="${gamecnt}"></span>回目で正解しました</p>
+
+        <!-- トップページへのリンク -->
+        <p class="text-center">
+          <a th:href="@{/soloNumeron/back}" class="btn btn-primary">トップページへ戻る</a>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Bootstrap JS and dependencies -->
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
マルチプレイの履歴の削除
playerに認証を追加したことで名前入力が不要になったので、その辺を削除＆調整。
wordLogにroomIdを紐図ける。
result画面(勝利画面)で”戻る”を押すとUserとLogの情報を削除。
soloResultの作成(multiと共有しているとwordLogの削除に不具合)。
終了時にmatchinfoDBのpplNumを”0”に変更。
[DoD]
名前入力が削除されているか=>h2-consoleでuesrDBにroomIdが含まれたuser情報が追加されているか
h2-consoleでwordLogDBにroomIdとuserIdが紐図いていることを確認。
h2-consoleで終了時にwordLogとUser情報が削除されていることを確認。
終了時に入室状況をリセットされているか確認。(h2-consoleも確認)。
